### PR TITLE
Implement AbLang/MPNN logit fusion utilities

### DIFF
--- a/logit_fusion.py
+++ b/logit_fusion.py
@@ -1,0 +1,46 @@
+import numpy as np
+import torch
+import torch.nn.functional as F
+
+from protein_mpnn_utils import ProteinMPNN
+
+try:
+    import ablang
+except ImportError:
+    ablang = None
+
+AA_ALPHABET = 'ACDEFGHIKLMNPQRSTVWY'
+AA_DICT = {a: i for i, a in enumerate(AA_ALPHABET)}
+
+
+def seq_to_tensor(seq):
+    idx = [AA_DICT.get(a, 0) for a in seq]
+    return torch.tensor(idx, dtype=torch.long)[None, :]
+
+
+def design_with_fusion(struct, start_seq, mask_positions, n_designs=100, T=0.1,
+                       seed=None):
+    if ablang is None:
+        raise ImportError("ablang package is required")
+
+    heavy = ablang.pretrained("heavy")
+    heavy.freeze()
+    light = ablang.pretrained("light")
+    light.freeze()
+
+    mpnn = struct["model"]
+    device = next(mpnn.parameters()).device
+    rng = np.random.default_rng(seed)
+
+    for _ in range(n_designs):
+        seq = list(start_seq)
+        order = rng.permutation(mask_positions)
+        for pos in order:
+            S = seq_to_tensor(seq).to(device)
+            logit_mpnn = mpnn.single_site_logits(struct, S, pos)[0].cpu().numpy()
+            logit_ab = heavy.single_site_logits(seq, pos) + light.single_site_logits(seq, pos)
+            fused = logit_mpnn + logit_ab
+            probs = F.softmax(torch.tensor(fused) / T, dim=-1).numpy()
+            choice = rng.choice(20, p=probs)
+            seq[pos] = AA_ALPHABET[choice]
+        yield "".join(seq)

--- a/protein_mpnn_utils.py
+++ b/protein_mpnn_utils.py
@@ -1381,3 +1381,62 @@ class ProteinMPNN(nn.Module):
         log_probs = F.log_softmax(logits, dim=-1)
         return log_probs
 
+    def encode_backbone(self, X, mask, residue_idx, chain_encoding_all):
+        """Precompute encoder representations for a backbone."""
+        E, E_idx = self.features(X, mask, residue_idx, chain_encoding_all)
+        h_V = torch.zeros((E.shape[0], E.shape[1], E.shape[-1]), device=E.device)
+        h_E = self.W_e(E)
+        mask_attend = gather_nodes(mask.unsqueeze(-1), E_idx).squeeze(-1)
+        mask_attend = mask.unsqueeze(-1) * mask_attend
+        for layer in self.encoder_layers:
+            h_V, h_E = layer(h_V, h_E, E_idx, mask, mask_attend)
+        return {
+            "h_V": h_V,
+            "h_E": h_E,
+            "E_idx": E_idx,
+            "mask": mask,
+        }
+
+    def single_site_logits(self, feats, S, residue):
+        """Return raw logits for one position given precomputed features."""
+        h_V_enc = feats["h_V"]
+        h_E = feats["h_E"]
+        E_idx = feats["E_idx"]
+        mask = feats["mask"]
+
+        device = h_V_enc.device
+        S = S.to(device)
+        chain_M = torch.zeros_like(mask)
+        chain_M[:, residue] = 1
+        randn = torch.zeros_like(chain_M)
+
+        mask_size = E_idx.shape[1]
+        permutation_matrix_reverse = torch.nn.functional.one_hot(
+            torch.argsort((chain_M + 0.0001) * torch.abs(randn)),
+            num_classes=mask_size,
+        ).float()
+        order_mask_backward = torch.einsum(
+            "ij, biq, bjp->bqp",
+            (1 - torch.triu(torch.ones(mask_size, mask_size, device=device))),
+            permutation_matrix_reverse,
+            permutation_matrix_reverse,
+        )
+        mask_attend = torch.gather(order_mask_backward, 2, E_idx).unsqueeze(-1)
+        mask_1D = mask.view(mask.size(0), mask.size(1), 1, 1)
+        mask_bw = mask_1D * mask_attend
+        mask_fw = mask_1D * (1.0 - mask_attend)
+
+        h_S = self.W_s(S)
+        h_ES = cat_neighbors_nodes(h_S, h_E, E_idx)
+        h_EX_encoder = cat_neighbors_nodes(torch.zeros_like(h_S), h_E, E_idx)
+        h_EXV_encoder = cat_neighbors_nodes(h_V_enc, h_EX_encoder, E_idx)
+        h_EXV_encoder_fw = mask_fw * h_EXV_encoder
+
+        h_V = h_V_enc.clone()
+        for layer in self.decoder_layers:
+            h_ESV = cat_neighbors_nodes(h_V, h_ES, E_idx)
+            h_ESV = mask_bw * h_ESV + h_EXV_encoder_fw
+            h_V = layer(h_V, h_ESV, mask)
+        logits = self.W_out(h_V)
+        return logits[:, residue, :]
+


### PR DESCRIPTION
## Summary
- add `encode_backbone` and `single_site_logits` methods to `ProteinMPNN` for single residue scoring
- new utility `logit_fusion.py` demonstrates the AbLang/MPNN logit fusion algorithm

## Testing
- `python -m py_compile logit_fusion.py protein_mpnn_utils.py`

------
https://chatgpt.com/codex/tasks/task_e_684f31d06488832a8f0de9e42b99c8ba